### PR TITLE
Add FFmpeg-based demo video editing pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dashboard/out/
 test-screenshots/
 *.png
 .playwright-mcp/
+scripts/demo-video/build/
+scripts/demo-video/raw/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-api dev-dash up down build logs install api dash test test-all lint fmt db db-reset db-shell clean doctor
+.PHONY: dev dev-api dev-dash up down build logs install api dash test test-all lint fmt db db-reset db-shell clean doctor demo-video demo-gif
 
 # ── Development (Docker) ───────────────────────────────────────────────────────
 dev: ## Start API + dashboard + postgres (dev mode)
@@ -70,5 +70,14 @@ doctor: ## Run rooben doctor
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+# ── Demo Video ────────────────────────────────────────────────────────────────
+demo-video: ## Build demo video from manifest (requires ffmpeg)
+	@command -v ffmpeg >/dev/null || (echo "Error: ffmpeg required. Install with: brew install ffmpeg" && exit 1)
+	cd scripts/demo-video && bash build.sh manifest.example.yaml
+
+demo-gif: ## Export GIF preview from demo video (requires ffmpeg)
+	@command -v ffmpeg >/dev/null || (echo "Error: ffmpeg required." && exit 1)
+	cd scripts/demo-video && bash 08-gif.sh build/rooben-demo-final.mp4 build/rooben-demo.gif
 
 .DEFAULT_GOAL := help

--- a/scripts/demo-video/01-trim.sh
+++ b/scripts/demo-video/01-trim.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# 01-trim.sh — Trim a raw clip to [start, end] and normalize to 1080p h264
+#
+# Usage: 01-trim.sh <input> <start> <end> <output>
+#   input   Path to raw video file (.mov, .mp4, etc.)
+#   start   Start timestamp (HH:MM:SS or seconds)
+#   end     End timestamp (HH:MM:SS or seconds)
+#   output  Output path (.mp4)
+#
+# Example:
+#   ./01-trim.sh raw/cli-demo.mov 00:00:02 00:00:45 build/trimmed/cli-demo.mp4
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 4 ]]; then
+    sed -n '2,12p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+INPUT="$1"
+START="$2"
+END="$3"
+OUTPUT="$4"
+
+[[ -f "$INPUT" ]] || log_error "Input file not found: $INPUT"
+require_ffmpeg
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+log_step "Trimming $(basename "$INPUT") [$START → $END]"
+
+# Build audio options — handle clips with no audio
+if has_audio "$INPUT"; then
+    ffmpeg -y -ss "$START" -to "$END" -i "$INPUT" \
+        -vf "scale=${RES_W}:${RES_H}:force_original_aspect_ratio=decrease,pad=${RES_W}:${RES_H}:(ow-iw)/2:(oh-ih)/2:color=${HEX_BG_DARK}" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" \
+        -pix_fmt "$PIX_FMT" -r "$FPS" \
+        -c:a "$AUDIO_CODEC" -b:a 128k \
+        "$OUTPUT" 2>/dev/null
+else
+    ffmpeg -y -ss "$START" -to "$END" -i "$INPUT" \
+        -f lavfi -i anullsrc=r=44100:cl=stereo \
+        -vf "scale=${RES_W}:${RES_H}:force_original_aspect_ratio=decrease,pad=${RES_W}:${RES_H}:(ow-iw)/2:(oh-ih)/2:color=${HEX_BG_DARK}" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" \
+        -pix_fmt "$PIX_FMT" -r "$FPS" \
+        -c:a "$AUDIO_CODEC" -b:a 128k \
+        -shortest \
+        "$OUTPUT" 2>/dev/null
+fi
+
+log_done "Trimmed → $(basename "$OUTPUT")"

--- a/scripts/demo-video/02-title-card.sh
+++ b/scripts/demo-video/02-title-card.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# 02-title-card.sh — Generate a branded title card with text
+#
+# Usage: 02-title-card.sh <title> <subtitle> [tagline] [duration] [output]
+#   title     Main title text (displayed in teal)
+#   subtitle  Subtitle text (displayed in white)
+#   tagline   Optional tagline (displayed in muted gray)
+#   duration  Duration in seconds (default: 4)
+#   output    Output path (default: build/titled/title-card.mp4)
+#
+# Example:
+#   ./02-title-card.sh "Rooben" "Autonomous Agent Orchestration" "Your taste is the product." 4
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 2 ]]; then
+    sed -n '2,13p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+TITLE="$1"
+SUBTITLE="$2"
+TAGLINE="${3:-}"
+DURATION="${4:-$DEFAULT_TITLE_DURATION}"
+OUTPUT="${5:-$BUILD_DIR/titled/title-card.mp4}"
+
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+[[ -z "$FONT_BOLD" ]] && log_error "No fonts found. Install dejavu-sans or set FONT_BOLD."
+
+log_step "Generating title card: \"$TITLE\""
+
+# Build the drawtext filter chain with staggered fade-in
+FILTER="color=c=${HEX_BG_DARK}:s=${RESOLUTION}:d=${DURATION}:r=${FPS}[bg];"
+FILTER+="[bg]"
+
+# Thin teal horizontal rule (centered, above subtitle area)
+FILTER+="drawbox=x=(iw/2)-120:y=(ih/2)-30:w=240:h=2:color=${HEX_TEAL}@0.6:t=fill,"
+
+# Title — large teal text, centered above the rule
+FILTER+="drawtext=fontfile='${FONT_BOLD}':"
+FILTER+="text='${TITLE//\'/\\\'}':"
+FILTER+="fontcolor=${HEX_TEAL}:fontsize=72:"
+FILTER+="x=(w-text_w)/2:y=(h/2)-100:"
+FILTER+="alpha='if(lt(t\,0.8)\,t/0.8\,1)',"
+
+# Subtitle — white, below the rule
+FILTER+="drawtext=fontfile='${FONT_PRIMARY}':"
+FILTER+="text='${SUBTITLE//\'/\\\'}':"
+FILTER+="fontcolor=${HEX_TEXT_PRIMARY}:fontsize=36:"
+FILTER+="x=(w-text_w)/2:y=(h/2)+20:"
+FILTER+="alpha='if(lt(t\,1.0)\,(t-0.2)/0.8\,if(lt(t\,0.2)\,0\,1))',"
+
+# Tagline — muted gray, smallest
+if [[ -n "$TAGLINE" ]]; then
+    FILTER+="drawtext=fontfile='${FONT_PRIMARY}':"
+    FILTER+="text='${TAGLINE//\'/\\\'}':"
+    FILTER+="fontcolor=${HEX_TEXT_SECONDARY}:fontsize=24:"
+    FILTER+="x=(w-text_w)/2:y=(h/2)+80:"
+    FILTER+="alpha='if(lt(t\,1.2)\,(t-0.4)/0.8\,if(lt(t\,0.4)\,0\,1))',"
+fi
+
+# Fade in/out on the whole card
+FADE_OUT_START=$(echo "$DURATION - $DEFAULT_FADE_OUT" | bc)
+FILTER+="fade=t=in:st=0:d=${DEFAULT_FADE_IN},"
+FILTER+="fade=t=out:st=${FADE_OUT_START}:d=${DEFAULT_FADE_OUT}"
+FILTER+="[v]"
+
+ffmpeg -y \
+    -f lavfi -i "color=c=${HEX_BG_DARK}:s=${RESOLUTION}:d=${DURATION}:r=${FPS}" \
+    -f lavfi -i "anullsrc=r=44100:cl=stereo" \
+    -filter_complex "$FILTER" \
+    -map "[v]" -map 1:a \
+    -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+    -c:a "$AUDIO_CODEC" -b:a 128k \
+    -shortest \
+    "$OUTPUT" 2>/dev/null
+
+log_done "Title card → $(basename "$OUTPUT") (${DURATION}s)"

--- a/scripts/demo-video/03-caption-overlay.sh
+++ b/scripts/demo-video/03-caption-overlay.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# 03-caption-overlay.sh — Add text captions to a video clip
+#
+# Usage: 03-caption-overlay.sh <input> <output> <caption_spec> [caption_spec...]
+#   input         Input video file
+#   output        Output video file
+#   caption_spec  Pipe-delimited: "text|start|end|position|style"
+#                 position: bottom (default), top, center
+#                 style: default (white sans-serif), code (green monospace)
+#
+# Example:
+#   ./03-caption-overlay.sh clip.mp4 out.mp4 "Hello world|0.5|4.5|bottom|default"
+#   ./03-caption-overlay.sh clip.mp4 out.mp4 "First caption|0|3|bottom|default" "Second|3.5|7|top|code"
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 3 ]]; then
+    sed -n '2,14p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+shift 2
+
+[[ -f "$INPUT" ]] || log_error "Input file not found: $INPUT"
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Build compound drawtext filter from all caption specs
+FILTER=""
+for spec in "$@"; do
+    TEXT=$(echo "$spec" | cut -d'|' -f1)
+    START=$(echo "$spec" | cut -d'|' -f2)
+    END=$(echo "$spec" | cut -d'|' -f3)
+    POSITION=$(echo "$spec" | cut -d'|' -f4)
+    STYLE=$(echo "$spec" | cut -d'|' -f5)
+
+    POSITION="${POSITION:-bottom}"
+    STYLE="${STYLE:-default}"
+
+    # Compute y position
+    case "$POSITION" in
+        top)    Y_EXPR="y=60" ;;
+        center) Y_EXPR="y=(h-text_h)/2" ;;
+        *)      Y_EXPR="y=h-text_h-60" ;;  # bottom
+    esac
+
+    # Escape single quotes in text for FFmpeg
+    TEXT="${TEXT//\'/\\\'}"
+    # Escape colons in text
+    TEXT="${TEXT//:/\\:}"
+
+    # Style-specific options
+    if [[ "$STYLE" == "code" ]]; then
+        FONT="$FONT_MONO"
+        FONTCOLOR="${HEX_EMERALD}"
+        FONTSIZE=28
+        BOXCOLOR="black@0.8"
+        BOXBORDER=16
+    else
+        FONT="$FONT_PRIMARY"
+        FONTCOLOR="white"
+        FONTSIZE=32
+        BOXCOLOR="black@0.6"
+        BOXBORDER=12
+    fi
+
+    [[ -n "$FILTER" ]] && FILTER+=","
+
+    FILTER+="drawtext=fontfile='${FONT}':"
+    FILTER+="text='${TEXT}':"
+    FILTER+="fontcolor=${FONTCOLOR}:fontsize=${FONTSIZE}:"
+    FILTER+="x=(w-text_w)/2:${Y_EXPR}:"
+    FILTER+="box=1:boxcolor=${BOXCOLOR}:boxborderw=${BOXBORDER}:"
+    FILTER+="enable='between(t\\,${START}\\,${END})'"
+done
+
+log_step "Adding $(echo "$@" | wc -w | tr -d ' ') caption(s) to $(basename "$INPUT")"
+
+ffmpeg -y -i "$INPUT" \
+    -vf "$FILTER" \
+    -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+    -c:a copy \
+    "$OUTPUT" 2>/dev/null
+
+log_done "Captioned → $(basename "$OUTPUT")"

--- a/scripts/demo-video/04-speed-ramp.sh
+++ b/scripts/demo-video/04-speed-ramp.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# 04-speed-ramp.sh — Change playback speed of a video clip
+#
+# Usage: 04-speed-ramp.sh <input> <output> <speed>
+#   input   Input video file
+#   output  Output video file
+#   speed   Speed multiplier (>1 = faster, <1 = slower)
+#           e.g., 1.5 = 1.5x faster, 0.5 = half speed
+#
+# Example:
+#   ./04-speed-ramp.sh clip.mp4 fast-clip.mp4 2.0
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 3 ]]; then
+    sed -n '2,12p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+SPEED="$3"
+
+[[ -f "$INPUT" ]] || log_error "Input file not found: $INPUT"
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Compute PTS factor: 1/speed (faster = smaller PTS)
+PTS_FACTOR=$(echo "scale=6; 1.0 / $SPEED" | bc)
+
+# Build atempo chain — atempo only accepts 0.5-2.0 range
+# For values outside this, chain multiple atempo filters
+build_atempo_chain() {
+    local speed="$1"
+    local chain=""
+
+    # Handle speeds > 2.0: chain atempo=2.0 repeatedly
+    while (( $(echo "$speed > 2.0" | bc -l) )); do
+        [[ -n "$chain" ]] && chain+=","
+        chain+="atempo=2.0"
+        speed=$(echo "scale=6; $speed / 2.0" | bc)
+    done
+
+    # Handle speeds < 0.5: chain atempo=0.5 repeatedly
+    while (( $(echo "$speed < 0.5" | bc -l) )); do
+        [[ -n "$chain" ]] && chain+=","
+        chain+="atempo=0.5"
+        speed=$(echo "scale=6; $speed / 0.5" | bc)
+    done
+
+    # Final atempo for remaining speed
+    [[ -n "$chain" ]] && chain+=","
+    chain+="atempo=${speed}"
+
+    echo "$chain"
+}
+
+ATEMPO_CHAIN=$(build_atempo_chain "$SPEED")
+
+log_step "Speed ${SPEED}x on $(basename "$INPUT")"
+
+if has_audio "$INPUT"; then
+    ffmpeg -y -i "$INPUT" \
+        -filter_complex "[0:v]setpts=${PTS_FACTOR}*PTS[v];[0:a]${ATEMPO_CHAIN}[a]" \
+        -map "[v]" -map "[a]" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+        -c:a "$AUDIO_CODEC" -b:a 128k \
+        "$OUTPUT" 2>/dev/null
+else
+    ffmpeg -y -i "$INPUT" \
+        -filter_complex "[0:v]setpts=${PTS_FACTOR}*PTS[v]" \
+        -map "[v]" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+        "$OUTPUT" 2>/dev/null
+fi
+
+log_done "Speed ${SPEED}x → $(basename "$OUTPUT")"

--- a/scripts/demo-video/05-transitions.sh
+++ b/scripts/demo-video/05-transitions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# 05-transitions.sh — Add fade-in and fade-out transitions to a video clip
+#
+# Usage: 05-transitions.sh <input> <output> [fade_in] [fade_out]
+#   input     Input video file
+#   output    Output video file
+#   fade_in   Fade-in duration in seconds (default: 0.5)
+#   fade_out  Fade-out duration in seconds (default: 0.5)
+#
+# Example:
+#   ./05-transitions.sh clip.mp4 faded-clip.mp4 0.5 0.3
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 2 ]]; then
+    sed -n '2,12p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+INPUT="$1"
+OUTPUT="$2"
+FADE_IN="${3:-$DEFAULT_FADE_IN}"
+FADE_OUT="${4:-$DEFAULT_FADE_OUT}"
+
+[[ -f "$INPUT" ]] || log_error "Input file not found: $INPUT"
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+DURATION=$(get_duration "$INPUT")
+FADE_OUT_START=$(echo "$DURATION - $FADE_OUT" | bc)
+
+log_step "Fading $(basename "$INPUT") [in:${FADE_IN}s out:${FADE_OUT}s]"
+
+VIDEO_FILTER="fade=t=in:st=0:d=${FADE_IN},fade=t=out:st=${FADE_OUT_START}:d=${FADE_OUT}"
+
+if has_audio "$INPUT"; then
+    AUDIO_FILTER="afade=t=in:st=0:d=${FADE_IN},afade=t=out:st=${FADE_OUT_START}:d=${FADE_OUT}"
+    ffmpeg -y -i "$INPUT" \
+        -vf "$VIDEO_FILTER" \
+        -af "$AUDIO_FILTER" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+        -c:a "$AUDIO_CODEC" -b:a 128k \
+        "$OUTPUT" 2>/dev/null
+else
+    ffmpeg -y -i "$INPUT" \
+        -vf "$VIDEO_FILTER" \
+        -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+        "$OUTPUT" 2>/dev/null
+fi
+
+log_done "Faded → $(basename "$OUTPUT")"

--- a/scripts/demo-video/06-add-music.sh
+++ b/scripts/demo-video/06-add-music.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# 06-add-music.sh — Mix background music into a video at low volume
+#
+# Usage: 06-add-music.sh <video> <music> <output> [volume]
+#   video   Input video file (with or without existing audio)
+#   music   Background music file (.mp3, .wav, etc.)
+#   output  Output video file
+#   volume  Music volume 0.0-1.0 (default: 0.08 = barely audible)
+#
+# Example:
+#   ./06-add-music.sh final.mp4 bg-track.mp3 final-with-music.mp4 0.08
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 3 ]]; then
+    sed -n '2,12p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+VIDEO="$1"
+MUSIC="$2"
+OUTPUT="$3"
+VOLUME="${4:-0.08}"
+
+[[ -f "$VIDEO" ]] || log_error "Video file not found: $VIDEO"
+[[ -f "$MUSIC" ]] || log_error "Music file not found: $MUSIC"
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+VIDEO_DURATION=$(get_duration "$VIDEO")
+FADE_OUT_START=$(echo "$VIDEO_DURATION - 3" | bc)
+
+log_step "Mixing music at ${VOLUME} volume"
+
+ffmpeg -y -i "$VIDEO" -i "$MUSIC" \
+    -filter_complex "
+        [1:a]aloop=loop=-1:size=2e+09,atrim=0:${VIDEO_DURATION},
+        volume=${VOLUME},
+        afade=t=in:st=0:d=2,
+        afade=t=out:st=${FADE_OUT_START}:d=3[music];
+        [0:a][music]amix=inputs=2:duration=first:dropout_transition=3[a]
+    " \
+    -map 0:v -map "[a]" \
+    -c:v copy \
+    -c:a "$AUDIO_CODEC" -b:a 192k \
+    "$OUTPUT" 2>/dev/null
+
+log_done "Music mixed → $(basename "$OUTPUT")"

--- a/scripts/demo-video/07-concat.sh
+++ b/scripts/demo-video/07-concat.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# 07-concat.sh — Concatenate multiple video segments into one video
+#
+# Usage: 07-concat.sh <output> <segment1> <segment2> ...
+#   output     Output video file
+#   segment*   Input video segments (in order)
+#
+# Example:
+#   ./07-concat.sh final.mp4 intro.mp4 demo.mp4 cta.mp4
+#   ./07-concat.sh final.mp4 build/segments/*.mp4
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 3 ]]; then
+    sed -n '2,12p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+OUTPUT="$1"
+shift
+SEGMENTS=("$@")
+
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Validate all segments exist
+for seg in "${SEGMENTS[@]}"; do
+    [[ -f "$seg" ]] || log_error "Segment not found: $seg"
+done
+
+log_step "Concatenating ${#SEGMENTS[@]} segments"
+
+# Build concat list file
+CONCAT_LIST="$BUILD_DIR/concat-list.txt"
+> "$CONCAT_LIST"
+for seg in "${SEGMENTS[@]}"; do
+    echo "file '$(realpath "$seg")'" >> "$CONCAT_LIST"
+done
+
+ffmpeg -y -f concat -safe 0 -i "$CONCAT_LIST" \
+    -c:v "$VIDEO_CODEC" -crf "$CRF" -preset "$PRESET" -pix_fmt "$PIX_FMT" \
+    -c:a "$AUDIO_CODEC" -b:a 128k \
+    "$OUTPUT" 2>/dev/null
+
+rm -f "$CONCAT_LIST"
+
+log_done "Concatenated → $(basename "$OUTPUT") (${#SEGMENTS[@]} segments)"

--- a/scripts/demo-video/08-gif.sh
+++ b/scripts/demo-video/08-gif.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 08-gif.sh — Export a high-quality GIF from a video (two-pass palette)
+#
+# Usage: 08-gif.sh <input> [output] [width] [fps] [max_duration]
+#   input         Input video file
+#   output        Output GIF path (default: build/<input-name>.gif)
+#   width         GIF width in pixels (default: 640)
+#   fps           GIF frame rate (default: 12)
+#   max_duration  Maximum duration in seconds (default: 15)
+#
+# Example:
+#   ./08-gif.sh build/rooben-demo-final.mp4
+#   ./08-gif.sh build/rooben-demo-final.mp4 build/rooben-demo.gif 640 12 15
+
+source "$(dirname "$0")/config.sh"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+    sed -n '2,13p' "$0" | sed 's/^# \?//'
+    exit 0
+fi
+
+INPUT="$1"
+BASENAME=$(basename "${INPUT%.*}")
+OUTPUT="${2:-$BUILD_DIR/${BASENAME}.gif}"
+WIDTH="${3:-$GIF_WIDTH}"
+GIF_FRAMERATE="${4:-$GIF_FPS}"
+MAX_DUR="${5:-$GIF_MAX_DURATION}"
+
+[[ -f "$INPUT" ]] || log_error "Input file not found: $INPUT"
+require_ffmpeg
+mkdir -p "$(dirname "$OUTPUT")"
+
+PALETTE="$BUILD_DIR/palette-${BASENAME}.png"
+
+log_step "Generating GIF (${WIDTH}px, ${GIF_FRAMERATE}fps, max ${MAX_DUR}s)"
+
+# Pass 1: Generate optimized palette
+ffmpeg -y -ss 0 -t "$MAX_DUR" -i "$INPUT" \
+    -vf "fps=${GIF_FRAMERATE},scale=${WIDTH}:-1:flags=lanczos,palettegen=stats_mode=diff" \
+    "$PALETTE" 2>/dev/null
+
+# Pass 2: Render GIF using palette
+ffmpeg -y -ss 0 -t "$MAX_DUR" -i "$INPUT" -i "$PALETTE" \
+    -lavfi "fps=${GIF_FRAMERATE},scale=${WIDTH}:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+    "$OUTPUT" 2>/dev/null
+
+rm -f "$PALETTE"
+
+GIF_SIZE=$(du -h "$OUTPUT" | cut -f1)
+log_done "GIF → $(basename "$OUTPUT") (${GIF_SIZE})"

--- a/scripts/demo-video/build.sh
+++ b/scripts/demo-video/build.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# build.sh — Master orchestrator for the Rooben demo video pipeline
+#
+# Usage: build.sh <manifest.yaml> [--gif] [--clean]
+#   manifest.yaml  Path to the video manifest file
+#   --gif          Also export a GIF preview after building
+#   --clean        Remove build/ directory before starting
+#
+# Example:
+#   ./build.sh manifest.example.yaml
+#   ./build.sh manifest.example.yaml --gif
+#   ./build.sh manifest.example.yaml --clean --gif
+
+source "$(dirname "$0")/config.sh"
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+MANIFEST=""
+OPT_GIF=0
+OPT_CLEAN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)
+            sed -n '2,13p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --gif)  OPT_GIF=1 ;;
+        --clean) OPT_CLEAN=1 ;;
+        *)
+            if [[ -z "$MANIFEST" ]]; then
+                MANIFEST="$arg"
+            fi
+            ;;
+    esac
+done
+
+[[ -n "$MANIFEST" ]] || log_error "Usage: build.sh <manifest.yaml> [--gif] [--clean]"
+[[ -f "$MANIFEST" ]] || log_error "Manifest not found: $MANIFEST"
+require_ffmpeg
+
+if [[ "$OPT_CLEAN" -eq 1 ]]; then
+    log_step "Cleaning build directory"
+    rm -rf "$BUILD_DIR"
+    ensure_build_dirs
+fi
+
+# ── Pure-bash YAML parser ────────────────────────────────────────────────────
+# Parses our simplified manifest format using awk/sed.
+# Handles: meta.*, music.*, segments with nested captions.
+
+# Read a simple key: yaml_get "meta.title"
+yaml_get() {
+    local key="$1"
+    local section="${key%%.*}"
+    local field="${key#*.}"
+    awk -v section="$section" -v field="$field" '
+        BEGIN { in_section=0 }
+        /^[a-z]/ {
+            gsub(/:.*/, "", $1)
+            if ($1 == section) in_section=1; else in_section=0
+        }
+        in_section && /^  [a-z]/ {
+            gsub(/^  /, "")
+            split($0, parts, ": ")
+            gsub(/^ +| +$/, "", parts[1])
+            if (parts[1] == field) {
+                val = $0
+                sub(/^[^:]*: */, "", val)
+                gsub(/^ +| +$/, "", val)
+                gsub(/^["'\''"]|["'\''"]$/, "", val)
+                print val
+                exit
+            }
+        }
+    ' "$MANIFEST"
+}
+
+# Parse all segments into parallel arrays
+parse_segments() {
+    SEGMENT_COUNT=0
+    local idx=-1
+    local in_segments=0
+
+    while IFS= read -r line; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+
+        # Detect segments section
+        if [[ "$line" =~ ^segments: ]]; then
+            in_segments=1
+            continue
+        fi
+
+        # Stop at next top-level key
+        if [[ $in_segments -eq 1 && "$line" =~ ^[a-z] && ! "$line" =~ ^segments: ]]; then
+            break
+        fi
+
+        [[ $in_segments -eq 0 ]] && continue
+
+        # New segment: "  - id: xxx"
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*id:[[:space:]]*(.*) ]]; then
+            idx=$((idx + 1))
+            SEGMENT_COUNT=$((idx + 1))
+            SEG_ID[$idx]=$(echo "${BASH_REMATCH[1]}" | xargs)
+            SEG_TYPE[$idx]=""
+            SEG_TITLE[$idx]=""
+            SEG_SUBTITLE[$idx]=""
+            SEG_TAGLINE[$idx]=""
+            SEG_DURATION[$idx]=""
+            SEG_SOURCE[$idx]=""
+            SEG_TRIM_START[$idx]=""
+            SEG_TRIM_END[$idx]=""
+            SEG_SPEED[$idx]=""
+            SEG_FADE_IN[$idx]=""
+            SEG_FADE_OUT[$idx]=""
+            SEG_CAPTIONS[$idx]=""
+            continue
+        fi
+
+        [[ $idx -lt 0 ]] && continue
+
+        # Caption line: "      - text|start|end|pos|style"
+        if [[ "$line" =~ ^[[:space:]]{6,}-[[:space:]]+(.*) ]]; then
+            local cap="${BASH_REMATCH[1]}"
+            if [[ -n "${SEG_CAPTIONS[$idx]}" ]]; then
+                SEG_CAPTIONS[$idx]+=$'\n'"$cap"
+            else
+                SEG_CAPTIONS[$idx]="$cap"
+            fi
+            continue
+        fi
+
+        # Segment field: "    key: value"
+        if [[ "$line" =~ ^[[:space:]]{4}([a-z_]+):[[:space:]]*(.*) ]]; then
+            local key="${BASH_REMATCH[1]}"
+            local val="${BASH_REMATCH[2]}"
+            # Strip surrounding quotes
+            val="${val#\"}"
+            val="${val%\"}"
+            val="${val#\'}"
+            val="${val%\'}"
+            val=$(echo "$val" | xargs)
+
+            case "$key" in
+                type)       SEG_TYPE[$idx]="$val" ;;
+                title)      SEG_TITLE[$idx]="$val" ;;
+                subtitle)   SEG_SUBTITLE[$idx]="$val" ;;
+                tagline)    SEG_TAGLINE[$idx]="$val" ;;
+                duration)   SEG_DURATION[$idx]="$val" ;;
+                source)     SEG_SOURCE[$idx]="$val" ;;
+                trim_start) SEG_TRIM_START[$idx]="$val" ;;
+                trim_end)   SEG_TRIM_END[$idx]="$val" ;;
+                speed)      SEG_SPEED[$idx]="$val" ;;
+                fade_in)    SEG_FADE_IN[$idx]="$val" ;;
+                fade_out)   SEG_FADE_OUT[$idx]="$val" ;;
+            esac
+        fi
+
+    done < "$MANIFEST"
+}
+
+# ── Parse manifest ───────────────────────────────────────────────────────────
+echo ""
+log_step "Parsing manifest: $(basename "$MANIFEST")"
+
+# Meta
+META_TITLE=$(yaml_get "meta.title")
+META_OUTPUT=$(yaml_get "meta.output")
+META_OUTPUT="${META_OUTPUT:-rooben-demo-final.mp4}"
+
+# Music
+MUSIC_FILE=$(yaml_get "music.file")
+MUSIC_VOLUME=$(yaml_get "music.volume")
+MUSIC_VOLUME="${MUSIC_VOLUME:-0.08}"
+
+# Segments
+declare -a SEG_ID SEG_TYPE SEG_TITLE SEG_SUBTITLE SEG_TAGLINE SEG_DURATION
+declare -a SEG_SOURCE SEG_TRIM_START SEG_TRIM_END SEG_SPEED SEG_FADE_IN SEG_FADE_OUT
+declare -a SEG_CAPTIONS
+SEGMENT_COUNT=0
+
+parse_segments
+
+echo "  Found $SEGMENT_COUNT segment(s)"
+[[ $SEGMENT_COUNT -gt 0 ]] || log_error "No segments found in manifest"
+
+# ── Process segments ─────────────────────────────────────────────────────────
+SEGMENT_FILES=()
+
+for i in $(seq 0 $((SEGMENT_COUNT - 1))); do
+    local_id="${SEG_ID[$i]}"
+    local_type="${SEG_TYPE[$i]}"
+    padded_idx=$(printf "%02d" "$i")
+    segment_output="$BUILD_DIR/segments/${padded_idx}-${local_id}.mp4"
+
+    echo ""
+    log_step "[$((i+1))/$SEGMENT_COUNT] Segment: $local_id ($local_type)"
+
+    if [[ "$local_type" == "title-card" ]]; then
+        # ── Title card ───────────────────────────────────────────────
+        local_title="${SEG_TITLE[$i]:-$META_TITLE}"
+        local_subtitle="${SEG_SUBTITLE[$i]:-}"
+        local_tagline="${SEG_TAGLINE[$i]:-}"
+        local_duration="${SEG_DURATION[$i]:-$DEFAULT_TITLE_DURATION}"
+
+        bash "$SCRIPT_DIR/02-title-card.sh" \
+            "$local_title" "$local_subtitle" "$local_tagline" \
+            "$local_duration" "$segment_output"
+
+    elif [[ "$local_type" == "clip" ]]; then
+        # ── Video clip: trim → caption → speed → fade ────────────────
+        local_source="${SEG_SOURCE[$i]}"
+        local_trim_start="${SEG_TRIM_START[$i]:-00:00:00}"
+        local_trim_end="${SEG_TRIM_END[$i]}"
+        local_speed="${SEG_SPEED[$i]:-1.0}"
+        local_fade_in="${SEG_FADE_IN[$i]:-$DEFAULT_FADE_IN}"
+        local_fade_out="${SEG_FADE_OUT[$i]:-$DEFAULT_FADE_OUT}"
+        local_captions="${SEG_CAPTIONS[$i]:-}"
+
+        [[ -f "$local_source" ]] || log_error "Source not found: $local_source (segment: $local_id)"
+
+        # Step 1: Trim
+        trimmed="$BUILD_DIR/trimmed/${padded_idx}-${local_id}.mp4"
+        bash "$SCRIPT_DIR/01-trim.sh" "$local_source" "$local_trim_start" "$local_trim_end" "$trimmed"
+        current="$trimmed"
+
+        # Step 2: Captions
+        if [[ -n "$local_captions" ]]; then
+            captioned="$BUILD_DIR/captioned/${padded_idx}-${local_id}.mp4"
+            caption_args=()
+            while IFS= read -r cap_line; do
+                [[ -n "$cap_line" ]] && caption_args+=("$cap_line")
+            done <<< "$local_captions"
+
+            if [[ ${#caption_args[@]} -gt 0 ]]; then
+                bash "$SCRIPT_DIR/03-caption-overlay.sh" "$current" "$captioned" "${caption_args[@]}"
+                current="$captioned"
+            fi
+        fi
+
+        # Step 3: Speed (skip if 1.0)
+        if [[ "$local_speed" != "1.0" && "$local_speed" != "1" ]]; then
+            sped="$BUILD_DIR/sped/${padded_idx}-${local_id}.mp4"
+            bash "$SCRIPT_DIR/04-speed-ramp.sh" "$current" "$sped" "$local_speed"
+            current="$sped"
+        fi
+
+        # Step 4: Transitions
+        bash "$SCRIPT_DIR/05-transitions.sh" "$current" "$segment_output" "$local_fade_in" "$local_fade_out"
+
+    else
+        log_error "Unknown segment type: $local_type (segment: $local_id)"
+    fi
+
+    SEGMENT_FILES+=("$segment_output")
+done
+
+# ── Concatenate ──────────────────────────────────────────────────────────────
+echo ""
+log_step "Concatenating ${#SEGMENT_FILES[@]} segments"
+
+CONCAT_OUTPUT="$BUILD_DIR/concat-raw.mp4"
+bash "$SCRIPT_DIR/07-concat.sh" "$CONCAT_OUTPUT" "${SEGMENT_FILES[@]}"
+
+# ── Music mix ────────────────────────────────────────────────────────────────
+FINAL_OUTPUT="$BUILD_DIR/$META_OUTPUT"
+
+if [[ -n "$MUSIC_FILE" && -f "$MUSIC_FILE" ]]; then
+    log_step "Adding background music"
+    bash "$SCRIPT_DIR/06-add-music.sh" "$CONCAT_OUTPUT" "$MUSIC_FILE" "$FINAL_OUTPUT" "$MUSIC_VOLUME"
+else
+    cp "$CONCAT_OUTPUT" "$FINAL_OUTPUT"
+fi
+
+# ── GIF export ───────────────────────────────────────────────────────────────
+if [[ "$OPT_GIF" -eq 1 ]]; then
+    echo ""
+    GIF_OUTPUT="$BUILD_DIR/${META_OUTPUT%.mp4}.gif"
+    bash "$SCRIPT_DIR/08-gif.sh" "$FINAL_OUTPUT" "$GIF_OUTPUT"
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+FINAL_SIZE=$(du -h "$FINAL_OUTPUT" | cut -f1)
+FINAL_DURATION=$(get_duration "$FINAL_OUTPUT")
+log_done "Build complete!"
+echo "  Output:   $FINAL_OUTPUT"
+echo "  Size:     $FINAL_SIZE"
+echo "  Duration: ${FINAL_DURATION}s"
+echo "  Segments: ${#SEGMENT_FILES[@]}"

--- a/scripts/demo-video/config.sh
+++ b/scripts/demo-video/config.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# config.sh — Central configuration for the Rooben demo video pipeline
+# Source this file from other scripts: source "$(dirname "$0")/config.sh"
+
+set -euo pipefail
+
+# ── Directories ───────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+RAW_DIR="${SCRIPT_DIR}/raw"
+ASSETS_DIR="${PROJECT_ROOT}/docs/assets"
+
+# ── Brand Colors (FFmpeg hex format) ──────────────────────────────────────────
+COLOR_TEAL="0x0d9488"
+COLOR_EMERALD="0x16a34a"
+COLOR_RED="0xdc2626"
+COLOR_VIOLET="0x7c3aed"
+COLOR_BG_DARK="0x0f172a"           # Slate-900 — dark card background
+COLOR_TEXT_PRIMARY="0xf8fafc"       # Slate-50  — bright white text
+COLOR_TEXT_SECONDARY="0x94a3b8"     # Slate-400 — muted secondary text
+
+# Hex versions for drawtext (# prefix)
+HEX_TEAL="#0d9488"
+HEX_EMERALD="#16a34a"
+HEX_BG_DARK="#0f172a"
+HEX_TEXT_PRIMARY="#f8fafc"
+HEX_TEXT_SECONDARY="#94a3b8"
+
+# ── Video Defaults ────────────────────────────────────────────────────────────
+RESOLUTION="1920x1080"
+RES_W=1920
+RES_H=1080
+FPS=30
+VIDEO_CODEC="libx264"
+AUDIO_CODEC="aac"
+CRF=18                              # Visually lossless
+PRESET="slow"                       # Quality over speed
+PIX_FMT="yuv420p"                   # Universal player compatibility
+
+# ── Font Configuration ────────────────────────────────────────────────────────
+# Try common Linux paths first, then macOS
+FONT_PRIMARY=""
+FONT_BOLD=""
+FONT_MONO=""
+
+font_candidates_primary=(
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    "/usr/share/fonts/TTF/DejaVuSans.ttf"
+    "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf"
+    "/System/Library/Fonts/Helvetica.ttc"
+    "/System/Library/Fonts/SFNSText.ttf"
+)
+font_candidates_bold=(
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+    "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf"
+    "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans-Bold.ttf"
+    "/System/Library/Fonts/Helvetica.ttc"
+    "/System/Library/Fonts/SFNSText-Bold.ttf"
+)
+font_candidates_mono=(
+    "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf"
+    "/usr/share/fonts/TTF/DejaVuSansMono.ttf"
+    "/usr/share/fonts/dejavu-sans-mono-fonts/DejaVuSansMono.ttf"
+    "/System/Library/Fonts/SFNSMono.ttf"
+    "/System/Library/Fonts/Menlo.ttc"
+)
+
+for f in "${font_candidates_primary[@]}"; do
+    [[ -f "$f" ]] && FONT_PRIMARY="$f" && break
+done
+for f in "${font_candidates_bold[@]}"; do
+    [[ -f "$f" ]] && FONT_BOLD="$f" && break
+done
+for f in "${font_candidates_mono[@]}"; do
+    [[ -f "$f" ]] && FONT_MONO="$f" && break
+done
+
+# Fall back to whatever is available
+if [[ -z "$FONT_PRIMARY" ]]; then
+    FONT_PRIMARY=$(fc-list : file | head -1 | cut -d: -f1 2>/dev/null || echo "")
+    FONT_BOLD="$FONT_PRIMARY"
+    FONT_MONO="$FONT_PRIMARY"
+fi
+
+# ── Default Durations (seconds) ──────────────────────────────────────────────
+DEFAULT_FADE_IN=0.5
+DEFAULT_FADE_OUT=0.5
+DEFAULT_TITLE_DURATION=4
+
+# ── GIF Settings ─────────────────────────────────────────────────────────────
+GIF_WIDTH=640
+GIF_FPS=12
+GIF_MAX_DURATION=15
+
+# ── Helper Functions ─────────────────────────────────────────────────────────
+
+# Print a step indicator
+log_step() {
+    echo -e "\033[36m▶\033[0m $1"
+}
+
+# Print success
+log_done() {
+    echo -e "\033[32m✓\033[0m $1"
+}
+
+# Print error and exit
+log_error() {
+    echo -e "\033[31m✗\033[0m $1" >&2
+    exit 1
+}
+
+# Check that ffmpeg is available
+require_ffmpeg() {
+    command -v ffmpeg &>/dev/null || log_error "ffmpeg not found. Install: brew install ffmpeg / apt install ffmpeg"
+    command -v ffprobe &>/dev/null || log_error "ffprobe not found. Install: brew install ffmpeg / apt install ffmpeg"
+}
+
+# Get video duration in seconds
+get_duration() {
+    ffprobe -v error -show_entries format=duration -of csv=p=0 "$1"
+}
+
+# Check if file has an audio stream
+has_audio() {
+    ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$1" 2>/dev/null | grep -q audio
+}
+
+# Ensure build directories exist
+ensure_build_dirs() {
+    mkdir -p "$BUILD_DIR"/{trimmed,titled,captioned,sped,segments}
+}
+
+# ── Initialize ───────────────────────────────────────────────────────────────
+ensure_build_dirs

--- a/scripts/demo-video/manifest.example.yaml
+++ b/scripts/demo-video/manifest.example.yaml
@@ -1,0 +1,109 @@
+# Rooben Demo Video Manifest
+# ─────────────────────────────────────────────────────────────────────────────
+# This file declaratively describes the full video structure.
+# Run: ./build.sh manifest.example.yaml
+#
+# Format notes:
+#   - Segments are processed in order (top to bottom)
+#   - type: "title-card" or "clip"
+#   - Captions use pipe-delimited format: text|start|end|position|style
+#   - Timestamps: HH:MM:SS for trim, decimal seconds for captions
+#   - Speed: >1 = faster, <1 = slower, 1 = normal
+
+meta:
+  title: Rooben Demo
+  tagline: Your taste is the product.
+  output: rooben-demo-final.mp4
+  resolution: 1920x1080
+  fps: 30
+
+music:
+  file:
+  volume: 0.08
+
+segments:
+
+  - id: intro
+    type: title-card
+    title: Rooben
+    subtitle: Autonomous Agent Orchestration
+    tagline: Your taste is the product.
+    duration: 4
+    fade_in: 0.8
+    fade_out: 0.5
+
+  - id: hook
+    type: clip
+    source: raw/01-result-preview.mov
+    trim_start: 00:00:00
+    trim_end: 00:00:12
+    speed: 1.0
+    fade_in: 0.5
+    fade_out: 0.3
+    captions:
+      - Rooben turns plain English into verified, multi-agent work product.|0.5|4.5|bottom|default
+      - With built-in cost tracking and proof of quality.|5.0|9.0|bottom|default
+
+  - id: problem
+    type: clip
+    source: raw/02-chatbot-comparison.mov
+    trim_start: 00:00:00
+    trim_end: 00:00:10
+    speed: 1.0
+    fade_in: 0.3
+    fade_out: 0.3
+    captions:
+      - AI chatbots give you text.|0.0|3.0|bottom|default
+      - Real work needs planning, execution, and verification.|3.5|7.0|bottom|default
+
+  - id: live-demo
+    type: clip
+    source: raw/03-cli-execution.mov
+    trim_start: 00:00:01
+    trim_end: 00:00:45
+    speed: 1.5
+    fade_in: 0.3
+    fade_out: 0.3
+    captions:
+      - rooben go "Build a REST API with tests"|0.0|4.0|bottom|code
+      - Spec generated, agents assigned, execution begins.|5.0|10.0|bottom|default
+
+  - id: dag-execution
+    type: clip
+    source: raw/04-dag-visualization.mov
+    trim_start: 00:00:03
+    trim_end: 00:00:25
+    speed: 2.0
+    fade_in: 0.5
+    fade_out: 0.5
+    captions:
+      - Parallel agents executing across dependency levels|1.0|5.0|bottom|default
+
+  - id: features-card
+    type: title-card
+    title: Key Features
+    subtitle: Verification / Cost Tracking / Budget Control
+    duration: 3
+    fade_in: 0.5
+    fade_out: 0.5
+
+  - id: verification
+    type: clip
+    source: raw/05-verification-scores.mov
+    trim_start: 00:00:00
+    trim_end: 00:00:15
+    speed: 1.0
+    fade_in: 0.3
+    fade_out: 0.3
+    captions:
+      - Every output verified with test runner + LLM judge|1.0|6.0|bottom|default
+      - Scores 0.92, 0.95 — real proof, not vibes.|7.0|12.0|bottom|default
+
+  - id: cta
+    type: title-card
+    title: Try Rooben
+    subtitle: github.com/blakeaber/rooben
+    tagline: Open source. Ship verified AI work.
+    duration: 5
+    fade_in: 0.8
+    fade_out: 1.0


### PR DESCRIPTION
## Summary

- **Declarative video pipeline** — describe your entire demo video in a YAML manifest (segments, captions, speeds, order), then run one command to build it
- **11 pure bash + FFmpeg scripts** — no Python or external dependencies beyond FFmpeg. Includes trim, branded title cards, caption overlays, speed ramp, fade transitions, background music mixing, concatenation, and two-pass GIF export
- **Makefile targets** — `make demo-video` and `make demo-gif` for quick builds

### How it works

1. Drop raw screen recordings into `scripts/demo-video/raw/`
2. Edit `manifest.example.yaml` to define your video structure
3. Run `./build.sh manifest.example.yaml` (or `make demo-video`)
4. Pipeline processes each segment: trim → captions → speed → fades → concat → music → final output

### Visual quality details

- CRF 18 / h264 for visually lossless output
- Dark slate title cards with teal brand accents and staggered text reveal
- Two-pass palette GIF generation for high-quality README embeds
- Auto-pillarboxing for non-16:9 inputs matching brand dark background

## Test plan

- [ ] Verify `./02-title-card.sh "Test" "Subtitle" "" 3 /tmp/test.mp4` produces a branded card
- [ ] Place a test `.mov` in `raw/`, run `./build.sh manifest.example.yaml` end-to-end
- [ ] Confirm `make demo-gif` exports a properly-dithered GIF
- [ ] Verify all scripts show help text with `--help`
- [ ] Test on both macOS and Linux font paths

https://claude.ai/code/session_011qKddMhc4P4fN47JhxH3K2