### PR TITLE
docs: link to predicate.ventures/writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,3 +538,10 @@ python -m pytest tests/ -v
 ## License
 
 [Apache-2.0](LICENSE) — Copyright (c) 2024 Blake Aber
+
+
+## 📝 Writing
+
+Deep-dives on the ideas behind this project: **[predicate.ventures/writing](https://www.predicate.ventures/writing)**.
+
+- [Specs, not prompts](https://www.predicate.ventures/writing/specs-not-prompts)


### PR DESCRIPTION
Adds a Writing backlink to predicate.ventures — a dofollow link home plus context for readers on the thinking behind this project.